### PR TITLE
Fix assertions so tests can fail if the app runs when it shouldn't

### DIFF
--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -132,20 +132,22 @@ def test_standalone__port_default(monkeypatch, app, mockfs_with_config):
 
 def test_standalone__port_invalid(monkeypatch, app, mockfs_with_config):
     monkeypatch.setattr(sys, 'argv', ["test.py", "-p", "pants"])
+    monkeypatch.setattr(jasmine.entry_points, 'JasmineApp', FakeApp)
 
     with pytest.raises(SystemExit):
         standalone()
 
     assert "invalid int value: 'pants'"
-    assert not app.run.called
+    assert not FakeApp.app.run.called
 
 
 def test_standalone__missing_config(monkeypatch, app, mockfs):
     monkeypatch.setattr(sys, 'argv', ["test.py"])
+    monkeypatch.setattr(jasmine.entry_points, 'JasmineApp', FakeApp)
 
     standalone()
 
-    assert not app.run.called
+    assert not FakeApp.app.run.called
 
 
 def test__query__yes(capsys, monkeypatch):

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -138,7 +138,7 @@ def test_standalone__port_invalid(monkeypatch, app, mockfs_with_config):
         standalone()
 
     assert "invalid int value: 'pants'"
-    assert not FakeApp.app.run.called
+    FakeApp.app.run.assert_not_called()
 
 
 def test_standalone__missing_config(monkeypatch, app, mockfs):
@@ -147,7 +147,7 @@ def test_standalone__missing_config(monkeypatch, app, mockfs):
 
     standalone()
 
-    assert not FakeApp.app.run.called
+    FakeApp.app.run.assert_not_called()
 
 
 def test__query__yes(capsys, monkeypatch):


### PR DESCRIPTION
Previously, when passing `mockfs_with_config` into `test_standalone__missing_config` and monkeypatch setting attributes for `FakeApp` in that test, the test would pass as it didn't assert on `FakeApp.app...`