### PR TITLE
Make jasmine yaml location configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ env
 htmlcov
 *.swp
 .cache
+.idea/*

--- a/jasmine/entry_points.py
+++ b/jasmine/entry_points.py
@@ -50,9 +50,13 @@ def continuous_integration():
 
 def _config_paths():
     project_path = os.path.realpath(os.path.dirname(__name__))
+    jasmine_conf = "spec/javascripts/support/jasmine.yml"
+    if 'JASMINE_CONFIG_PATH' in os.environ:
+        jasmine_conf = os.environ['JASMINE_CONFIG_PATH']
+
     config_file = os.path.join(
         project_path,
-        "spec/javascripts/support/jasmine.yml"
+        jasmine_conf
     )
     return config_file, project_path
 

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -132,20 +132,22 @@ def test_standalone__port_default(monkeypatch, app, mockfs_with_config):
 
 def test_standalone__port_invalid(monkeypatch, app, mockfs_with_config):
     monkeypatch.setattr(sys, 'argv', ["test.py", "-p", "pants"])
+    monkeypatch.setattr(jasmine.entry_points, 'JasmineApp', FakeApp)
 
     with pytest.raises(SystemExit):
         standalone()
 
     assert "invalid int value: 'pants'"
-    assert not app.run.called
+    assert not FakeApp.app.run.called
 
 
 def test_standalone__missing_config(monkeypatch, app, mockfs):
     monkeypatch.setattr(sys, 'argv', ["test.py"])
+    monkeypatch.setattr(jasmine.entry_points, 'JasmineApp', FakeApp)
 
     standalone()
 
-    assert not app.run.called
+    assert not FakeApp.app.run.called
 
 
 def test__query__yes(capsys, monkeypatch):

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -138,7 +138,7 @@ def test_standalone__port_invalid(monkeypatch, app, mockfs_with_config):
         standalone()
 
     assert "invalid int value: 'pants'"
-    assert not FakeApp.app.run.called
+    FakeApp.app.run.assert_not_called()
 
 
 def test_standalone__missing_config(monkeypatch, app, mockfs):
@@ -147,7 +147,7 @@ def test_standalone__missing_config(monkeypatch, app, mockfs):
 
     standalone()
 
-    assert not FakeApp.app.run.called
+    FakeApp.app.run.assert_not_called()
 
 
 def test__query__yes(capsys, monkeypatch):


### PR DESCRIPTION
As in node jasmine, jasmine-py can now pick up an exported `JASMINE_CONFIG_PATH` environment variable for a path to `jasmine.yml`