### PR TITLE
Command.init should have "args" argument as other commands do, even if it ignores them

### DIFF
--- a/jasmine/entry_points.py
+++ b/jasmine/entry_points.py
@@ -129,7 +129,7 @@ class Command(object):
             elif choice in valid:
                 return valid[choice]
 
-    def init(self):
+    def init(self, args):
         from jasmine.console_formatter import ConsoleFormatter
 
         spec_dir = os.path.join(os.getcwd(), 'spec/javascripts/')

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -245,7 +245,7 @@ def test_init__yes(monkeypatch):
 
         input_string(monkeypatch, "Y")
 
-        Command(None, None).init()
+        Command(None, None).init(None)
 
         assert os.path.isdir(spec_dir)
         assert os.path.isfile(yaml_file)
@@ -269,7 +269,7 @@ def test_init__yes__existing_yaml(monkeypatch):
     
         input_string(monkeypatch, "Y")
     
-        Command(None, None).init()
+        Command(None, None).init(None)
     
         assert os.path.isdir(spec_dir)
         assert os.path.isfile(yaml_file)
@@ -288,7 +288,15 @@ def test_init__no(monkeypatch):
     
         input_string(monkeypatch, "N")
     
-        Command(None, None).init()
+        Command(None, None).init(None)
     
         assert not os.path.isdir(spec_dir)
         assert not os.path.isfile(yaml_file)
+
+
+def test_init__run(monkeypatch):
+    with in_temp_dir():
+        cmd = Command(FakeApp, FakeCI)
+        input_string(monkeypatch, "N")
+
+        cmd.run(['init'])


### PR DESCRIPTION
Command.run will call one of the command methods with whatever
parse_args returns. Previously, Command.init did not accept any other
arguments and would raise a TypeError when called.

Fixes #48