### PR TITLE
Not all expectations have a "stack" entry

### DIFF
--- a/jasmine/console_formatter.py
+++ b/jasmine/console_formatter.py
@@ -138,10 +138,10 @@ class ConsoleFormatter(object):
         return output
 
     def _format_expectation_failure(self, expectation):
-        return (
-            "  " + expectation['message'] + "\n" +
-            "  " + self.clean_stack(expectation['stack']) + "\n"
-        )
+            output = "  " + expectation['message'] + "\n"
+            if 'stack' in expectation:
+                output += "  " + self.clean_stack(expectation['stack']) + "\n"
+            return output
 
     def _colorize(self, color, text):
         if not self.colors:

--- a/test/console_formatter_test.py
+++ b/test/console_formatter_test.py
@@ -90,6 +90,12 @@ def test_format_suite_errors():
             u'failedExpectations': [
                 {"message": "boom", "stack": "stack3"},
             ]
+        },
+        {
+            u'status': u'failed',
+            u'failedExpectations': [
+                {"message": "nope"},
+            ]
         }
     ])
 
@@ -101,7 +107,8 @@ def test_format_suite_errors():
            + "  oh no!\n" \
            + "  stack2\n" \
            + "  boom\n" \
-           + "  stack3\n"
+           + "  stack3\n" \
+           + "  nope\n"
 
 
 def test_format_browser_logs(results, browser_logs):


### PR DESCRIPTION
Certain errors don't  have a "stack" value, which jasmine-py does not expect.

For example, syntax and reference errors will cause the following exception:

```
Traceback (most recent call last):
  File "/home/travis/build/Inboxen/Inboxen/.tox/js-fx/bin/jasmine", line 11, in <module>
    sys.exit(begin())
  File "/home/travis/build/Inboxen/Inboxen/.tox/js-fx/lib/python3.6/site-packages/jasmine/entry_points.py", line 15, in begin
    cmd.run(sys.argv[1:])
  File "/home/travis/build/Inboxen/Inboxen/.tox/js-fx/lib/python3.6/site-packages/jasmine/entry_points.py", line 64, in run
    args.func(args)
  File "/home/travis/build/Inboxen/Inboxen/.tox/js-fx/lib/python3.6/site-packages/jasmine/entry_points.py", line 85, in ci
    app=jasmine_app,
  File "/home/travis/build/Inboxen/Inboxen/.tox/js-fx/lib/python3.6/site-packages/jasmine/ci.py", line 64, in run
    str_output = formatter.format()
  File "/home/travis/build/Inboxen/Inboxen/.tox/js-fx/lib/python3.6/site-packages/jasmine/console_formatter.py", line 37, in format
    self.format_pending() +
  File "/home/travis/build/Inboxen/Inboxen/.tox/js-fx/lib/python3.6/site-packages/jasmine/console_formatter.py", line 74, in format_suite_failure
    output += self._format_expectation_failure(expectation)
  File "/home/travis/build/Inboxen/Inboxen/.tox/js-fx/lib/python3.6/site-packages/jasmine/console_formatter.py", line 143, in _format_expectation_failure
    "  " + self.clean_stack(expectation['stack']) + "\n"
KeyError: 'stack'
```

(In this case `excpectation['message']` contained "ReferenceError: jQuery is not defined")

Tests have been updated too.